### PR TITLE
feat: improve bed leveling precision and speed

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -93,9 +93,9 @@
 #ifndef MOTHERBOARD
   #define MOTHERBOARD BOARD_MKS_E3D_V2
   #if ENABLED(RTS_AVAILABLE)
-    //#define NEPTUNE_3_PRO      1
+    #define NEPTUNE_3_PRO      1
     //#define NEPTUNE_3_PLUS   1
-    #define NEPTUNE_3_MAX    1
+    //#define NEPTUNE_3_MAX    1
     #endif
 #endif
 
@@ -1182,11 +1182,11 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 300, 300, 10, 25 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
-  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10, 50 } // ...or, set your own edit limits
+  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 20, 50 } // ...or, set your own edit limits
 #endif
 
 /**
@@ -1510,13 +1510,13 @@
 #endif
 
 // X and Y axis travel speed (mm/min) between probes
-#define XY_PROBE_FEEDRATE (133*60)
+#define XY_PROBE_FEEDRATE (300*60)
 
 // Feedrate (mm/min) for the first approach when double-probing (MULTIPLE_PROBING == 2)
-#define Z_PROBE_FEEDRATE_FAST (4*60)
+#define Z_PROBE_FEEDRATE_FAST (10*60)
 
 // Feedrate (mm/min) for the "accurate" probe of each point
-#define Z_PROBE_FEEDRATE_SLOW (Z_PROBE_FEEDRATE_FAST / 2)
+#define Z_PROBE_FEEDRATE_SLOW (6*60)
 
 /**
  * Probe Activation Switch
@@ -1563,7 +1563,7 @@
  * A total of 2 does fast/slow probes with a weighted average.
  * A total of 3 or more adds more slow probes, taking the average.
  */
-//#define MULTIPLE_PROBING 2
+#define MULTIPLE_PROBING 2
 //#define EXTRA_PROBING    1
 
 /**
@@ -1585,7 +1585,7 @@
 #define Z_CLEARANCE_MULTI_PROBE     5 // Z Clearance between multiple probes
 //#define Z_AFTER_PROBING           5 // Z position after probing is done
 
-#define Z_PROBE_LOW_POINT          -2 // Farthest distance below the trigger-point to go before stopping
+#define Z_PROBE_LOW_POINT          -1 // Farthest distance below the trigger-point to go before stopping
 
 // For M851 give a range for adjusting the Z probe offset
 #define Z_PROBE_OFFSET_RANGE_MIN -20


### PR DESCRIPTION
### Description

This significantly improves the ABL algorithm by enabling multiple Z-probing. The default ABL routine only uses one probe, so it has to be slow to be accurate. By turning on the multiple Z-probing feature, machine speed limits during probing can be increased without losing accuracy. These changes increase XY moves during Z-probing to 300 mm/sec, and Z probe speed to 12mm/sec during fast probe and 6mm/sec during slow probe.

*NOTE*: Maximum Z movement speed under machine limits was increased to 10. This should be safe, because it's the same as what some other i3-like printers use, but please test if this is ok on Neptune 3 Pro.

### Requirements

Neptune 3 Pro

### Benefits

I tested this on my Neptune 3 Pro, doing 20 bed levels with the default ABL configuration and 20 bed levels with this tweaked configuration.

The stock firmware leveled the bed in about 4 minutes and 20 seconds, with a standard deviation of 0.029 mm.
My tweaks leveled the bed in about 3 minutes and 15 seconds, with a standard deviation of 0.006 mm. This is faster and more precise!

The Z-probe tweaks I applied are similar to the way that the Prusa Mini has this configured.

Full data from my testing is available [here](https://1drv.ms/x/s!AveDyRw3IP3nisVxFJaO4qTokfYiCA?e=SwoYdU).

### Configurations

N/A

### Related Issues

N/A
