### PR TITLE
进入文件列表菜单时如果不在打印状态.重新挂载SD卡,这样可以防止中途松动导致后面打印文件时出错.

### DIFF
--- a/Marlin/src/lcd/extui/dgus/elegoo/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/elegoo/DGUSDisplayDef.cpp
@@ -744,6 +744,11 @@
     // represents to update file list
     if(CardUpdate && lcd_sd_status && RTS_SD_Detected())
     {
+      //If you are not in the printing state when entering the file list menu, remount the SD card to prevent it from loosening halfway and causing errors when printing documents later
+      if(!card.isPrinting()){
+        RTS_SDCardInit();
+      }
+
       for(uint16_t i = 0;i < CardRecbuf.Filesum;i ++)
       {
         delay(1);


### PR DESCRIPTION
进入文件列表菜单时如果不在打印状态.重新挂载SD卡,这样可以防止中途松动导致后面打印文件时出错.之前出现过卡松动后选择文件打印,界面一直停留在正在打印界面不动了.并且可以支持WIFI无线传输模块更新文件后刷新列表.经过了很多次测试没问题.